### PR TITLE
[ remove ] twitter/x timeline.

### DIFF
--- a/pages/00-index.md
+++ b/pages/00-index.md
@@ -2,16 +2,15 @@
 title: Home
 ---
 
-<a class="twitter-timeline" href="https://twitter.com/scottish_pli?ref_src=twsrc%5Etfw">Tweets by scottish_pli</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-
 The Scottish Programming Languages Institute (SPLI) co-ordinates community events which enhance programming languages research in Scotland.
 
 It unites researchers in programming languages from the University of Edinburgh, the University of Glasgow, Heriot-Watt University, the University of St Andrews, the University of Stirling, the University of Strathclyde, and the University of the West of Scotland. To learn more about the structure of the SPLI, see our [organisation](/01-people.html) page.
 
 Researchers within SPLI cover a broad range of topics under the Programming Languages umbrella, ranging from theoretical foundations, semantics and verification to implementation, compilation and optimisation. For students interested in pursuing a PhD in Programming Languages at an SPLI institution, a list of potential supervisors can be found on our [studentships](/03-studentships.html) page.
 
-For information on the events we run, including the Scottish Programming Languages Seminar series (SPLS) and the Scottish Programming Languages and Verification Summer School (SPLV), please see our [events](/02-events.html) page. 
+For information on the events we run, including the Scottish Programming Languages Seminar series (SPLS) and the Scottish Programming Languages and Verification Summer School (SPLV), please see our [events](/02-events.html) page.
 
-We also run a lively online community on our [Zulip](http://spls.zulipchat.com/) instance, where many SPLI activities and events are co-ordinated. 
+We also run a lively online community on our [Zulip](http://spls.zulipchat.com/) instance, where many SPLI activities and events are co-ordinated.
+We are on [X](https://twitter.com/scottish_pli) as well.
 
 We collaborate with the [Scottish Informatics and Computer Science Alliance](https://www.sicsa.ac.uk/) (SICSA), to promote and support activities, especially for PhD students.


### PR DESCRIPTION
The widget for the twitter stream was no longer working. So let's remove it.

Feel free to change the wording of the X online presence.